### PR TITLE
Prs/implement preflight requires

### DIFF
--- a/src/rookify/modules/__init__.py
+++ b/src/rookify/modules/__init__.py
@@ -21,41 +21,65 @@ class ModuleLoadException(Exception):
         self.module_name = module_name
         self.message = message
 
-def load_modules(module_names: list) -> list:
+def load_modules(module_names: list) -> tuple[list, list]:
     """
     Dynamically loads modules from the 'modules' package.
 
     :param module_names: The module names to load
+    :return: returns tuple of preflight_modules, modules
     """
+
+    # Sanity checks for modules
+    def check_module_sanity(module_name: str, module: module):
+        for attr_type, attr_name in (
+            (ModuleHandler, 'HANDLER_CLASS'),
+            (str, 'MODULE_NAME'),
+            (list, 'REQUIRES'),
+            (list, 'AFTER'),
+            (list, 'PREFLIGHT_REQUIRES')
+        ):
+            if not hasattr(module, attr_name):
+                raise ModuleLoadException(module_name, f'Module has no attribute {attr_name}')
+
+            attr = getattr(module, attr_name)
+            if not isinstance(attr, attr_type) and not issubclass(attr, attr_type):
+                raise ModuleLoadException(module_name, f'Attribute {attr_name} is not type {attr_type}')
 
     # Load the modules in the given list and recursivley load required modules
     required_modules = OrderedDict()
-    def load_required_modules(module_names: list, modules: OrderedDict) -> None:
+    def load_required_modules(modules_out: OrderedDict, module_names: list) -> None:
         for module_name in module_names:
-            if module_name in modules:
+            if module_name in modules_out:
                 continue
 
-            module = importlib.import_module(f"rookify.modules.{module_name}")
+            module = importlib.import_module(f".{module_name}", 'rookify.modules')
+            check_module_sanity(module_name, module)
 
-            for attr_type, attr_name in (
-                (ModuleHandler, 'HANDLER_CLASS'),
-                (str, 'MODULE_NAME'),
-                (list, 'REQUIRES'),
-                (list, 'AFTER'),
-                (bool, 'RUN_IN_PREFLIGHT')
-            ):
-                if not hasattr(module, attr_name):
-                    raise ModuleLoadException(module_name, f'Module has no attribute {attr_name}')
-
-                attr = getattr(module, attr_name)
-                if not isinstance(attr, attr_type) and not issubclass(attr, attr_type):
-                    raise ModuleLoadException(module_name, f'Attribute {attr_name} is not type {attr_type}')
-
-            load_required_modules(module.REQUIRES, modules)
+            load_required_modules(modules_out, module.REQUIRES)
             module.AFTER.extend(module.REQUIRES)
 
-            modules[module_name] = module
-    load_required_modules(module_names, required_modules)
+            modules_out[module_name] = module
+    load_required_modules(required_modules, module_names)
+
+    # Recursively load the modules in the PREFLIGHT_REQUIRES attribute of the given modules
+    preflight_modules = OrderedDict()
+    def load_preflight_modules(modules_in: OrderedDict, modules_out: OrderedDict, module_names: list) -> None:
+        for module_name in module_names:
+            if module_name in modules_out:
+                continue
+
+            module = importlib.import_module(f".{module_name}", 'rookify.modules')
+            check_module_sanity(module_name, module)
+
+            # We have to check, if the preflight_requires list is already loaded as migration requirement
+            for preflight_requirement in module.PREFLIGHT_REQUIRES:
+                if preflight_requirement in modules_in:
+                    raise ModuleLoadException(module_name, f'Module {preflight_requirement} is already loaded as migration requirement')
+
+            load_preflight_modules(modules_in, modules_out, module.PREFLIGHT_REQUIRES)
+            if module_name not in modules_in:
+                modules_out[module_name] = module
+    load_preflight_modules(required_modules, preflight_modules, required_modules.keys())
 
     # Sort the modules by the AFTER keyword
     modules = OrderedDict()
@@ -73,4 +97,4 @@ def load_modules(module_names: list) -> list:
             modules_out[module_name] = modules_in[module_name]
     sort_modules(required_modules, modules, list(required_modules.keys()))
 
-    return list(modules.values())
+    return list(preflight_modules.values()), list(modules.values())

--- a/src/rookify/modules/analyze_ceph/__init__.py
+++ b/src/rookify/modules/analyze_ceph/__init__.py
@@ -4,6 +4,6 @@ from .main import AnalyzeCephHandler
 
 MODULE_NAME = 'analyze_ceph'
 HANDLER_CLASS = AnalyzeCephHandler
-RUN_IN_PREFLIGHT = True
 REQUIRES = []
 AFTER = []
+PREFLIGHT_REQUIRES = []

--- a/src/rookify/modules/example/__init__.py
+++ b/src/rookify/modules/example/__init__.py
@@ -4,6 +4,6 @@ from .main import ExampleHandler
 
 MODULE_NAME = 'example' # Name of the module
 HANDLER_CLASS = ExampleHandler # Define the handler class for this module
-RUN_IN_PREFLIGHT = False # This executes the run method during preflight checks. This is neccessary for analyze modules.
-REQUIRES = ['analyze_ceph'] # A list of modules that are required to run before this module. Modules in this list will be imported, even if they are not configured
+REQUIRES = [] # A list of modules that are required to run before this module. Modules in this list will be imported, even if they are not configured
 AFTER = ['migrate_monitors'] # A list of modules that should be run before this module, if they are defined in config
+PREFLIGHT_REQUIRES = ['analyze_ceph'] # A list of modules that are required to run the preflight_check of this module. Modules in this list will be imported and run in preflight stage.

--- a/src/rookify/modules/migrate_monitors/__init__.py
+++ b/src/rookify/modules/migrate_monitors/__init__.py
@@ -4,6 +4,6 @@ from .main import MigrateMonitorsHandler
 
 MODULE_NAME = 'migrate_monitors'
 HANDLER_CLASS = MigrateMonitorsHandler
-RUN_IN_PREFLIGHT = False
-REQUIRES = ['analyze_ceph']
+REQUIRES = []
 AFTER = []
+PREFLIGHT_REQUIRES = ['analyze_ceph']

--- a/src/rookify/modules/migrate_osds/__init__.py
+++ b/src/rookify/modules/migrate_osds/__init__.py
@@ -4,6 +4,6 @@ from .main import MigrateOSDsHandler
 
 MODULE_NAME = 'migrate_osds'
 HANDLER_CLASS = MigrateOSDsHandler
-RUN_IN_PREFLIGHT = False
-REQUIRES = ['analyze_ceph']
+REQUIRES = []
 AFTER = ['migrate_monitors']
+PREFLIGHT_REQUIRES = [ 'analyze_ceph' ]


### PR DESCRIPTION
The earlier method to run modules before preflight checks was a little bit unclean, because it was easy to destroy the dependency tree