### PR TITLE
Various fixes for build and workflow code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "setuptools", "wheel" ]
 build-backend = "setuptools.build_meta"
 
 [project]
-dynamic = ["dependencies", "scripts", "version"]
+dynamic = ["dependencies", "optional-dependencies", "scripts", "version"]
 requires-python = ">=3.9"
 
 name = "Rookify"

--- a/src/rookify/modules/machine.py
+++ b/src/rookify/modules/machine.py
@@ -28,7 +28,8 @@ class Machine(_Machine):  # type: ignore
 
     def execute(self) -> None:
         for state in self._preflight_states + self._execution_states:
-            self.add_state(state)
+            if state.name not in self.states:
+                self.add_state(state)
 
         self.add_state("migrated")
         self.add_ordered_transitions(loop=False)

--- a/src/rookify/modules/module.py
+++ b/src/rookify/modules/module.py
@@ -213,7 +213,12 @@ class ModuleHandler:
         pass
 
     def load_template(self, filename: str, **variables: Any) -> __Template:
-        template_path = os.path.join(os.path.dirname(__file__), "templates", filename)
+        template_path = os.path.join(
+            os.path.dirname(__file__),
+            self.__class__.__module__.rsplit(".", 2)[1],
+            "templates",
+            filename,
+        )
         template = ModuleHandler.__Template(template_path)
         template.render(**variables)
         return template


### PR DESCRIPTION
During development multiple issues showed up that are fixed with this PR:
- The template path used for each module was constructed in a wrong way leading to `No such file or directory` errors
- States are scheduled multiple times even if already added to `transitions` 
- A warning is displayed while building Python packages because `optional-dependencies` are not marked as dynamic in `pyproject.toml`