### PR TITLE
feat: make rookify execute on run only

### DIFF
--- a/src/rookify/__main__.py
+++ b/src/rookify/__main__.py
@@ -15,15 +15,27 @@ def parse_args(args: list[str]) -> argparse.Namespace:
     # Putting args-parser in seperate function to make this testable
     arg_parser = ArgumentParser("Rookify")
 
-    # --dry-run option
-    arg_parser.add_argument("--dry-run", action="store_true", dest="dry_run_mode")
+    arg_parser.add_argument("-d", "--dry-run", action="store_true", dest="dry_run_mode")
 
     arg_parser.add_argument(
+        "-s",
         "--show-states",
         action="store_true",
         dest="show_states",
         help="Show states of the modules.",
     )
+
+    arg_parser.add_argument(
+        "run",
+        nargs="?",
+        default=False,
+        help="Run the migration.",
+    )
+
+    # Show help if no arguments are provided
+    if not args:
+        arg_parser.print_help()
+        sys.exit(1)
 
     return arg_parser.parse_args(args)
 
@@ -59,7 +71,7 @@ def main() -> None:
 
     if args.show_states is True:
         ModuleHandler.show_states(machine, config)
-    else:
+    if args.run:
         machine.execute(dry_run_mode=args.dry_run_mode)
 
 

--- a/src/rookify/__main__.py
+++ b/src/rookify/__main__.py
@@ -15,14 +15,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
     # Putting args-parser in seperate function to make this testable
     arg_parser = ArgumentParser("Rookify")
 
-    arg_parser.add_argument("-d", "--dry-run", action="store_true", dest="dry_run_mode")
-
     arg_parser.add_argument(
-        "-s",
-        "--show-states",
+        "-d",
+        "--dry-run",
         action="store_true",
-        dest="show_states",
-        help="Show states of the modules.",
+        dest="dry_run_mode",
+        help="Preflight data analysis and migration validation.",
     )
 
     arg_parser.add_argument(
@@ -33,12 +31,18 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         help="Run the migration.",
     )
 
-    # Show help if no arguments are provided
-    if not args:
-        print("No arguments provided.")
-        return arg_parser.parse_args(["--dry-run"])
-    else:
-        return arg_parser.parse_args(args)
+    arg_parser.add_argument(
+        "-s",
+        "--show-states",
+        action="store_true",
+        dest="show_states",
+        help="Show states of the modules.",
+    )
+
+    if len(args) < 1:
+        args = ["--dry-run"]
+
+    return arg_parser.parse_args(args)
 
 
 def main() -> None:
@@ -52,7 +56,7 @@ def main() -> None:
 
     # Configure logging
     try:
-        if args.show_states is True:
+        if args.show_states:
             configure_logging(
                 {"level": "ERROR", "format": {"renderer": "console", "time": "iso"}}
             )
@@ -68,13 +72,13 @@ def main() -> None:
 
     load_modules(machine, config)
 
-    if args.show_states is True:
-        log.info("Showing Rookify state ...")
+    if args.show_states:
+        log.debug("Showing Rookify state ...")
         ModuleHandler.show_states(machine, config)
-    elif args.dry_run_mode is True:
-        log.info("Running Rookify in dry-run-mode ...")
+    elif args.dry_run_mode:
+        log.info("Running Rookify in dry-run mode ...")
         machine.execute(dry_run_mode=args.dry_run_mode)
-    elif args.execution_mode is True:
+    else:
         log.info("Executing Rookify ...")
         machine.execute()
 

--- a/src/rookify/__main__.py
+++ b/src/rookify/__main__.py
@@ -26,18 +26,19 @@ def parse_args(args: list[str]) -> argparse.Namespace:
     )
 
     arg_parser.add_argument(
-        "run",
-        nargs="?",
-        default=False,
+        "-m",
+        "--migrate",
+        action="store_true",
+        dest="execution_mode",
         help="Run the migration.",
     )
 
     # Show help if no arguments are provided
     if not args:
-        arg_parser.print_help()
-        sys.exit(1)
-
-    return arg_parser.parse_args(args)
+        print("No arguments provided.")
+        return arg_parser.parse_args(["--dry-run"])
+    else:
+        return arg_parser.parse_args(args)
 
 
 def main() -> None:
@@ -63,16 +64,19 @@ def main() -> None:
     # Get Logger
     log = get_logger()
 
-    log.info("Executing Rookify ...")
-
     machine = Machine(config["general"].get("machine_pickle_file"))
 
     load_modules(machine, config)
 
     if args.show_states is True:
+        log.info("Showing Rookify state ...")
         ModuleHandler.show_states(machine, config)
-    if args.run:
+    elif args.dry_run_mode is True:
+        log.info("Running Rookify in dry-run-mode ...")
         machine.execute(dry_run_mode=args.dry_run_mode)
+    elif args.execution_mode is True:
+        log.info("Executing Rookify ...")
+        machine.execute()
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,10 +17,12 @@ TestCase = Tuple[List[str], argparse.Namespace]
 
 # fmt: off
 test_cases: List[TestCase] = [
-    (["--dry-run"], argparse.Namespace(dry_run_mode=True, show_states=False)),
-    (["--show-states"], argparse.Namespace(dry_run_mode=False, show_states=True)),
-    (["--dry-run", "--show-states"], argparse.Namespace(dry_run_mode=True, show_states=True)),
-    ([], argparse.Namespace(dry_run_mode=False, show_states=False)),
+    (["--migrate"], argparse.Namespace(dry_run_mode=False, show_states=False, execution_mode=True)),
+    (["--migrate", "--dry-run"], argparse.Namespace(dry_run_mode=True, show_states=False, execution_mode=True)),
+    (["--dry-run"], argparse.Namespace(dry_run_mode=True, show_states=False, execution_mode=False)),
+    (["--show-states"], argparse.Namespace(dry_run_mode=False, show_states=True, execution_mode=False)),
+    (["--dry-run", "--show-states"], argparse.Namespace(dry_run_mode=True, show_states=True, execution_mode=False)),
+    ([], argparse.Namespace(dry_run_mode=True, show_states=False, execution_mode=False)),
 ]
 # fmt: on
 


### PR DESCRIPTION
- Add `run` to execute and run `--help` per default
- Add short version for CLI 

closes #87 

```bash
.venv/bin/rookify
usage: Rookify [-h] [-d] [-s] [run]

positional arguments:
  run                Run the migration.

options:
  -h, --help         show this help message and exit
  -d, --dry-run
  -s, --show-states  Show states of the modules.
```