### PR TITLE
Ensure we are validating current Ceph status data for migration

### DIFF
--- a/src/rookify/modules/migrate_rgws/main.py
+++ b/src/rookify/modules/migrate_rgws/main.py
@@ -137,7 +137,11 @@ class MigrateRgwsHandler(ModuleHandler):
             )
 
             while True:
-                rgw_daemon_hosts = self._get_rgw_daemon_hosts()
+                ceph_status = self.ceph.mon_command("status")
+
+                rgw_daemon_hosts = self._get_rgw_daemon_hosts_of_map(
+                    ceph_status["servicemap"]["services"]["rgw"]["daemons"]
+                )
 
                 if rgw_host in rgw_daemon_hosts:
                     break


### PR DESCRIPTION
Changes introduced in #86 and updated in #93 only partly considered when data is taken from `analyze_ceph` and when to query Ceph for current status data. This resulted in always assuming RGW daemons got successfully migrated immediately.

Related: #98 