### PR TITLE
Remove `user` and `password` values for PyPI release workflow

### DIFF
--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -68,6 +68,3 @@ jobs:
         python -m build .
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PROD_PASSWORD }}


### PR DESCRIPTION
This PR removes left-over `user` and `password` values in our PyPI release workflow.