### PR TITLE
Use correct RGW systemd file name template

### DIFF
--- a/src/rookify/modules/ceph.py
+++ b/src/rookify/modules/ceph.py
@@ -71,7 +71,7 @@ class Ceph:
 
     def get_systemd_rgw_file_name(self, host: str) -> str:
         return self._get_systemd_template_file_name(
-            self._systemd_file_name_templates.get("mon", "ceph-radosgw.target"),
+            self._systemd_file_name_templates.get("rgw", "ceph-radosgw.target"),
             host,
         )
 


### PR DESCRIPTION
Fixes an issue found related to #106 with systemd RGW systemd file name template not being usable at all.

Fixes: #106